### PR TITLE
MLM: pass max seq length param to padding function

### DIFF
--- a/fasthugs_language_model.ipynb
+++ b/fasthugs_language_model.ipynb
@@ -560,7 +560,7 @@
    "outputs": [],
    "source": [
     "#collapse\n",
-    "padding=transformer_mlm_padding(tokenizer)\n",
+    "padding=transformer_mlm_padding(tokenizer,max_seq_len)\n",
     "\n",
     "bs=4\n",
     "dls = dsets.dataloaders(bs=bs, before_batch=[padding])"


### PR DESCRIPTION
Hi! First of all thanks for you work, it's really valuable and helpful.

My sessions were crashing because a model I use - available on the HF zoo - has `tokenizer.max_len == 1000000000000` (I suppose it's not the only one) and `max_seq_len` atm is not being passed onto the `transformer_mlm_padding` call.
This thus ignores any override and results in very funny 8TB allocation reqs at `pad =  x.new_zeros(max_len_l[idx]-x.shape[0])+pad_idx`.

This MR fixes it, preserving expected behaviour when `max_seq_len` is left as `None`.