### PR TITLE
fix max_len problem

### DIFF
--- a/fasthugs_language_model.ipynb
+++ b/fasthugs_language_model.ipynb
@@ -237,8 +237,8 @@
     "\n",
     "    def do_tokenize(self, o:str):\n",
     "        \"\"\"Returns tokenized text, adds prefix space if needed, limits the maximum sequence length\"\"\"\n",
-    "        if 'roberta' in model_name: tokens=self.tok.tokenize(o, add_prefix_space=True)[:self.max_seq_len]\n",
-    "        else: tokens = self.tok.tokenize(o)[:self.max_seq_len]\n",
+    "        if 'roberta' in model_name: tokens=self.tok.tokenize(o, add_prefix_space=True)[:self.max_seq_len-2]\n",
+    "        else: tokens = self.tok.tokenize(o)[:self.max_seq_len-2]\n",
     "        return tokens\n",
     "    \n",
     "    def de_tokenize(self, o):\n",
@@ -271,7 +271,7 @@
    },
    "outputs": [],
    "source": [
-    "max_seq_len = None  \n",
+    "max_seq_len = 512  \n",
     "sentence_pair=False\n",
     "\n",
     "fasthugstok = partial(FastHugsTokenizer, transformer_tokenizer=tokenizer, model_name=model_name, \n",
@@ -559,7 +559,7 @@
    "outputs": [],
    "source": [
     "#collapse\n",
-    "padding=transformer_mlm_padding(tokenizer)\n",
+    "padding=transformer_mlm_padding(tokenizer, max_seq_len=max_seq_len)\n",
     "\n",
     "bs=4\n",
     "dls = dsets.dataloaders(bs=bs, before_batch=[padding])"
@@ -2012,7 +2012,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,

--- a/fasthugs_seq_classification.ipynb
+++ b/fasthugs_seq_classification.ipynb
@@ -128,8 +128,8 @@
     "\n",
     "    def do_tokenize(self, o:str):\n",
     "        \"\"\"Returns tokenized text, adds prefix space if needed, limits the maximum sequence length\"\"\"\n",
-    "        if 'roberta' in model_name: tokens=self.tok.tokenize(o, add_prefix_space=True)[:self.max_seq_len]\n",
-    "        else: tokens = self.tok.tokenize(o)[:self.max_seq_len]\n",
+    "        if 'roberta' in model_name: tokens=self.tok.tokenize(o, add_prefix_space=True)[:self.max_seq_len-2]\n",
+    "        else: tokens = self.tok.tokenize(o)[:self.max_seq_len-2]\n",
     "        return tokens\n",
     "    def __call__(self, items): \n",
     "        for o in items: yield self.do_tokenize(o)"
@@ -312,7 +312,7 @@
    },
    "outputs": [],
    "source": [
-    "max_seq_len = None  \n",
+    "max_seq_len = 512  \n",
     "sentence_pair=False\n",
     "\n",
     "fasthugstok = partial(FastHugsTokenizer, transformer_tokenizer=tokenizer, model_name=model_name, \n",
@@ -402,7 +402,7 @@
    },
    "outputs": [],
    "source": [
-    "fht=FastHugsTokenizer(transformer_tokenizer=tokenizer, model_name='roberta', max_seq_len=None, \n",
+    "fht=FastHugsTokenizer(transformer_tokenizer=tokenizer, model_name='roberta', max_seq_len=max_seq_len, \n",
     "                 pretrained=True, pair=False)\n",
     "tokenized_text = next(fht(txt))"
    ]
@@ -594,7 +594,7 @@
    "outputs": [],
    "source": [
     "bs = 4\n",
-    "padding=transformer_padding(tokenizer)\n",
+    "padding=transformer_padding(tokenizer, max_seq_len)\n",
     "dls = dsets.dataloaders(bs=bs, before_batch=[padding])"
    ]
   },
@@ -1259,7 +1259,49 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.6"
+   "version": "3.6.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  },
+  "varInspector": {
+   "cols": {
+    "lenName": 16,
+    "lenType": 16,
+    "lenVar": 40
+   },
+   "kernels_config": {
+    "python": {
+     "delete_cmd_postfix": "",
+     "delete_cmd_prefix": "del ",
+     "library": "var_list.py",
+     "varRefreshCmd": "print(var_dic_list())"
+    },
+    "r": {
+     "delete_cmd_postfix": ") ",
+     "delete_cmd_prefix": "rm(",
+     "library": "var_list.r",
+     "varRefreshCmd": "cat(var_dic_list()) "
+    }
+   },
+   "types_to_exclude": [
+    "module",
+    "function",
+    "builtin_function_or_method",
+    "instance",
+    "_Feature"
+   ],
+   "window_display": false
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hi Morgan, thank you for your hard work, it helps me so much! However, when I tried to run your notebooks, I got some errors.

First, I think the max_seq_len should be assigned to a fix number (ex. 512), as in my case, the default tokenizer.max_len is 1000000000000000019884624838656, which is too large, triggering a cuda error.

Second, in the FastHugsTokenizer class, do_tokenize function should keep the length of the tokenized sequence to (max_len - 2), as in bert-like models, two extra token will be added (ex. [cls] and [sep] in bert, [s] and [/s] in roberta). In my case, when I kept the tokenized seq length to max_len, dls.one_batch() raised a error like this: RuntimeError: Trying to create tensor with negative dimension -2: [-2].

This PR fixes the above problems.